### PR TITLE
Mark when `Ecosystem`, `Hardware` and `Plants` "objects" are not in Gaia `ecosystems.cfg` anymore

### DIFF
--- a/src/ouranos/aggregator/events.py
+++ b/src/ouranos/aggregator/events.py
@@ -345,7 +345,7 @@ class Events:
                 await Ecosystem.update_or_create(
                     session, {
                         **ecosystem,
-                        "in_use":True,
+                        "in_config":True,
                         "last_seen": datetime.now(timezone.utc)
                     }
                 )
@@ -408,7 +408,7 @@ class Events:
                 stmt = (
                     delete(EnvironmentParameter)
                     .where(EnvironmentParameter.ecosystem_uid == uid)
-                    .where(Hardware.uid.not_in(environment_parameters_in_config))
+                    .where(EnvironmentParameter.parameter.not_in(environment_parameters_in_config))
                 )
                 await session.execute(stmt)
 
@@ -444,7 +444,7 @@ class Events:
                     # TODO: register multiplexer ?
                     del hardware["multiplexer_model"]
                     await Hardware.update_or_create(
-                        session, values={**hardware, "in_use": True},
+                        session, values={**hardware, "in_config": True},
                         uid=hardware_uid)
                     await sleep(0)
 

--- a/src/ouranos/aggregator/events.py
+++ b/src/ouranos/aggregator/events.py
@@ -422,7 +422,7 @@ class Events:
             result = await session.execute(stmt)
             inactive = result.scalars().all()
             for hardware in inactive:
-                hardware.status = False
+                hardware.in_use = False
         self.logger.debug(
             f"Logged hardware info from ecosystem(s): {humanize_list(ecosystems_to_log)}"
         )

--- a/src/ouranos/core/database/models/gaia.py
+++ b/src/ouranos/core/database/models/gaia.py
@@ -148,6 +148,20 @@ class GaiaBase(Base):
         raise NotImplementedError
 
 
+class RemovableMixin:
+    in_use: Mapped[bool] = mapped_column(default=True)
+
+    @classmethod
+    @abstractmethod
+    async def get_multiple(
+            cls,
+            session: AsyncSession,
+            uid: str | list | None = None,
+            in_use: bool | None = None
+    ) -> Sequence[Self]:
+        raise NotImplementedError
+
+
 # ---------------------------------------------------------------------------
 #   Ecosystems-related models, located in db_main and db_archive
 # ---------------------------------------------------------------------------
@@ -228,7 +242,7 @@ class Engine(GaiaBase):
         return response
 
 
-class Ecosystem(GaiaBase):
+class Ecosystem(RemovableMixin, GaiaBase):
     __tablename__ = "ecosystems"
 
     uid: Mapped[str] = mapped_column(sa.String(length=8), primary_key=True)
@@ -296,6 +310,7 @@ class Ecosystem(GaiaBase):
             cls,
             session: AsyncSession,
             ecosystems: str | list[str] | None = None,
+            in_use: bool | None = None,
     ) -> Sequence[Ecosystem]:
         if ecosystems is None:
             stmt = (
@@ -303,6 +318,8 @@ class Ecosystem(GaiaBase):
                 .order_by(Ecosystem.name.asc(),
                           Ecosystem.last_seen.desc())
             )
+            if in_use is not None:
+                stmt = stmt.where(cls.in_use == in_use)
             result = await session.execute(stmt)
             return result.scalars().all()
 
@@ -328,6 +345,8 @@ class Ecosystem(GaiaBase):
                        Ecosystem.name.in_(ecosystems))
                 .order_by(Ecosystem.last_seen.desc(), Ecosystem.name.asc())
             )
+        if in_use is not None:
+            stmt = stmt.where(cls.in_use == in_use)
         result = await session.execute(stmt)
         return result.scalars().all()
 
@@ -791,7 +810,7 @@ AssociationActuatorPlant = Table(
 )
 
 
-class Hardware(GaiaBase):
+class Hardware(RemovableMixin, GaiaBase):
     __tablename__ = "hardware"
 
     uid: Mapped[str] = mapped_column(sa.String(length=32), primary_key=True)
@@ -802,7 +821,6 @@ class Hardware(GaiaBase):
     address: Mapped[str] = mapped_column(sa.String(length=32))
     type: Mapped[HardwareType] = mapped_column()
     model: Mapped[str] = mapped_column(sa.String(length=32))
-    status: Mapped[bool] = mapped_column(default=True)
     last_log: Mapped[Optional[datetime]] = mapped_column()
 
     # relationships
@@ -917,10 +935,13 @@ class Hardware(GaiaBase):
             levels: HardwareLevelNames | list[HardwareLevelNames] | None = None,
             types: HardwareTypeNames | list[HardwareTypeNames] | None = None,
             models: str | list | None = None,
+            in_use: bool | None = None,
     ) -> Sequence[Hardware]:
         stmt = cls.generate_query(
             hardware_uids, ecosystem_uids, levels, types, models
         )
+        if in_use is not None:
+            stmt = stmt.where(cls.in_use == in_use)
         result = await session.execute(stmt)
         return result.unique().scalars().all()
 
@@ -976,11 +997,14 @@ class Sensor(Hardware):
             levels: HardwareLevelNames | list[HardwareLevelNames] | None = None,
             models: str | list | None = None,
             time_window: timeWindow = None,
+            in_use: bool | None = None,
     ) -> Sequence[Self]:
         stmt = cls.generate_query(
             hardware_uids, ecosystem_uids, levels, HardwareType.sensor.value, models)
         if time_window:
             stmt = cls._add_time_window_to_stmt(stmt, time_window)
+        if in_use is not None:
+            stmt = stmt.where(cls.in_use == in_use)
         result = await session.execute(stmt)
         return result.unique().scalars().all()
 
@@ -1107,11 +1131,14 @@ class Actuator(Hardware):
             levels: HardwareLevelNames | list[HardwareLevelNames] | None = None,
             models: str | list | None = None,
             time_window: timeWindow = None,
+            in_use: bool | None = None,
     ) -> Sequence[Self]:
         stmt = cls.generate_query(
             hardware_uids, ecosystem_uids, levels, type, models)
         if time_window:
             stmt = cls._add_time_window_to_stmt(stmt, time_window)
+        if in_use is not None:
+            stmt = stmt.where(cls.in_use == in_use)
         result = await session.execute(stmt)
         hardware: Sequence[Hardware] = result.unique().scalars().all()
         return [h for h in hardware if h.type != HardwareType.sensor]
@@ -1186,7 +1213,7 @@ class Measure(GaiaBase):
         return result.scalars().all()
 
 
-class Plant(GaiaBase):
+class Plant(RemovableMixin, GaiaBase):
     __tablename__ = "plants"
     uid: Mapped[str] = mapped_column(sa.String(16), primary_key=True)
     name: Mapped[str] = mapped_column(sa.String(32))
@@ -1217,7 +1244,8 @@ class Plant(GaiaBase):
     async def get_multiple(
             cls,
             session: AsyncSession,
-            plants_id: list[str] | None = None
+            plants_id: list[str] | None = None,
+            in_use: bool | None = None,
     ) -> Sequence[Self]:
         stmt = select(cls)
         if plants_id:
@@ -1225,6 +1253,8 @@ class Plant(GaiaBase):
                 (cls.name.in_(plants_id))
                 | (cls.uid.in_(plants_id))
             )
+        if in_use is not None:
+            stmt = stmt.where(cls.in_use == in_use)
         result = await session.execute(stmt)
         return result.scalars().all()
 

--- a/src/ouranos/web_server/routes/gaia/ecosystem.py
+++ b/src/ouranos/web_server/routes/gaia/ecosystem.py
@@ -43,12 +43,12 @@ router = APIRouter(
 
 id_param = Path(description="An ecosystem id, either its uid or its name")
 
-in_use_query = Query(
+in_config_query = Query(
     default=None, description="Only select ecosystems that are present (True) "
                               "or have been removed (False) from the current "
                               "gaia ecosystems config")
 
-in_use_query_hardware = Query(
+in_config_query_hardware = Query(
     default=None, description="Only select hardware that are present (True) "
                               "or have been removed (False) from the current "
                               "gaia ecosystems config")
@@ -75,11 +75,11 @@ async def environment_parameter_or_abort(
 @router.get("", response_model=list[EcosystemInfo])
 async def get_ecosystems(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id, in_use=in_use)
+        session=session, ecosystems=ecosystems_id, in_config=in_use)
     return ecosystems
 
 
@@ -221,11 +221,11 @@ async def get_managements_available():
 @router.get("/management", response_model=list[EcosystemManagementInfo])
 async def get_ecosystems_management(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id, in_use=in_use)
+        session=session, ecosystems=ecosystems_id, in_config=in_use)
     response = [
         await ecosystem.functionalities(session)
         for ecosystem in ecosystems
@@ -291,11 +291,11 @@ async def get_ecosystems_sensors_skeleton(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
         level: list[HardwareLevel] | None = hardware_level_q,
         time_window: timeWindow = Depends(get_time_window),
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id, in_use=in_use)
+        session=session, ecosystems=ecosystems_id, in_config=in_use)
     response = [
         await ecosystem.sensors_data_skeleton(session, time_window, level)
         for ecosystem in ecosystems
@@ -578,23 +578,23 @@ async def create_ecosystem_hardware(
 @router.get("/u/{id}/hardware", response_model=list[HardwareInfo])
 async def get_ecosystem_hardware(
         id: str = id_param,
-        in_use: bool | None = in_use_query_hardware,
+        in_use: bool | None = in_config_query_hardware,
         session: AsyncSession = Depends(get_session),
 ):
     hardware = await Hardware.get_multiple(
         session=session, hardware_uids=None, ecosystem_uids=id, levels=None,
-        types=None, models=None, in_use=in_use)
+        types=None, models=None, in_config=in_use)
     return hardware
 
 
 @router.get("/current_data", response_model=list[EcosystemSensorData])
 async def get_ecosystems_current_data(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id, in_use=in_use)
+        session=session, ecosystems=ecosystems_id, in_config=in_use)
     response = [
         {
             "ecosystem_uid": ecosystem.uid,
@@ -621,11 +621,11 @@ async def get_ecosystem_current_data(
 @router.get("/actuators_status", response_model=list[EcosystemActuatorStatus])
 async def get_ecosystems_actuators_status(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id, in_use=in_use)
+        session=session, ecosystems=ecosystems_id, in_config=in_use)
     response = [
         {
             "ecosystem_uid": ecosystem.uid,

--- a/src/ouranos/web_server/routes/gaia/ecosystem.py
+++ b/src/ouranos/web_server/routes/gaia/ecosystem.py
@@ -43,6 +43,15 @@ router = APIRouter(
 
 id_param = Path(description="An ecosystem id, either its uid or its name")
 
+in_use_query = Query(
+    default=None, description="Only select ecosystems that are present (True) "
+                              "or have been removed (False) from the current "
+                              "gaia ecosystems config")
+
+in_use_query_hardware = Query(
+    default=None, description="Only select hardware that are present (True) "
+                              "or have been removed (False) from the current "
+                              "gaia ecosystems config")
 
 env_parameter_query = Query(
     default=None, description="The environment parameter targeted. Leave empty "
@@ -66,10 +75,11 @@ async def environment_parameter_or_abort(
 @router.get("", response_model=list[EcosystemInfo])
 async def get_ecosystems(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
+        in_use: bool | None = in_use_query,
         session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id)
+        session=session, ecosystems=ecosystems_id, in_use=in_use)
     return ecosystems
 
 
@@ -211,9 +221,11 @@ async def get_managements_available():
 @router.get("/management", response_model=list[EcosystemManagementInfo])
 async def get_ecosystems_management(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        session: AsyncSession = Depends(get_session)
+        in_use: bool | None = in_use_query,
+        session: AsyncSession = Depends(get_session),
 ):
-    ecosystems = await Ecosystem.get_multiple(session, ecosystems_id)
+    ecosystems = await Ecosystem.get_multiple(
+        session=session, ecosystems=ecosystems_id, in_use=in_use)
     response = [
         await ecosystem.functionalities(session)
         for ecosystem in ecosystems
@@ -279,9 +291,11 @@ async def get_ecosystems_sensors_skeleton(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
         level: list[HardwareLevel] | None = hardware_level_q,
         time_window: timeWindow = Depends(get_time_window),
-        session: AsyncSession = Depends(get_session)
+        in_use: bool | None = in_use_query,
+        session: AsyncSession = Depends(get_session),
 ):
-    ecosystems = await Ecosystem.get_multiple(session, ecosystems_id)
+    ecosystems = await Ecosystem.get_multiple(
+        session=session, ecosystems=ecosystems_id, in_use=in_use)
     response = [
         await ecosystem.sensors_data_skeleton(session, time_window, level)
         for ecosystem in ecosystems
@@ -564,20 +578,23 @@ async def create_ecosystem_hardware(
 @router.get("/u/{id}/hardware", response_model=list[HardwareInfo])
 async def get_ecosystem_hardware(
         id: str = id_param,
+        in_use: bool | None = in_use_query_hardware,
         session: AsyncSession = Depends(get_session),
 ):
     hardware = await Hardware.get_multiple(
-        session, None, id, None, None, None)
+        session=session, hardware_uids=None, ecosystem_uids=id, levels=None,
+        types=None, models=None, in_use=in_use)
     return hardware
 
 
 @router.get("/current_data", response_model=list[EcosystemSensorData])
 async def get_ecosystems_current_data(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        session: AsyncSession = Depends(get_session)
+        in_use: bool | None = in_use_query,
+        session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id)
+        session=session, ecosystems=ecosystems_id, in_use=in_use)
     response = [
         {
             "ecosystem_uid": ecosystem.uid,
@@ -602,12 +619,13 @@ async def get_ecosystem_current_data(
 
 
 @router.get("/actuators_status", response_model=list[EcosystemActuatorStatus])
-async def get_ecosystems_current_data(
+async def get_ecosystems_actuators_status(
         ecosystems_id: list[str] | None = ecosystems_uid_q,
-        session: AsyncSession = Depends(get_session)
+        in_use: bool | None = in_use_query,
+        session: AsyncSession = Depends(get_session),
 ):
     ecosystems = await Ecosystem.get_multiple(
-        session=session, ecosystems=ecosystems_id)
+        session=session, ecosystems=ecosystems_id, in_use=in_use)
     response = [
         {
             "ecosystem_uid": ecosystem.uid,

--- a/src/ouranos/web_server/routes/gaia/hardware.py
+++ b/src/ouranos/web_server/routes/gaia/hardware.py
@@ -35,7 +35,7 @@ router = APIRouter(
 
 uid_param = Path(description="The uid of a hardware")
 
-in_use_query = Query(
+in_config_query = Query(
     default=None, description="Only select hardware that are present (True) "
                               "or have been removed (False) from the current "
                               "gaia ecosystems config")
@@ -66,13 +66,13 @@ async def get_multiple_hardware(
             default=None, description="A list of types of hardware"),
         hardware_model: list[str] | None = Query(
             default=None, description="A list of precise hardware model"),
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     hardware = await Hardware.get_multiple(
         session=session, hardware_uids=hardware_uid,
         ecosystem_uids=ecosystems_uid, levels=hardware_level,
-        types=hardware_type, models=hardware_model, in_use=in_use)
+        types=hardware_type, models=hardware_model, in_config=in_use)
     return hardware
 
 

--- a/src/ouranos/web_server/routes/gaia/hardware.py
+++ b/src/ouranos/web_server/routes/gaia/hardware.py
@@ -35,10 +35,10 @@ router = APIRouter(
 
 uid_param = Path(description="The uid of a hardware")
 
-level_query = Query(
-    default=None,
-    description="The level at which the hardware operates"
-)
+in_use_query = Query(
+    default=None, description="Only select hardware that are present (True) "
+                              "or have been removed (False) from the current "
+                              "gaia ecosystems config")
 
 
 async def hardware_or_abort(
@@ -66,11 +66,13 @@ async def get_multiple_hardware(
             default=None, description="A list of types of hardware"),
         hardware_model: list[str] | None = Query(
             default=None, description="A list of precise hardware model"),
+        in_use: bool | None = in_use_query,
         session: AsyncSession = Depends(get_session),
 ):
     hardware = await Hardware.get_multiple(
-        session, hardware_uid, ecosystems_uid, hardware_level,
-        hardware_type, hardware_model)
+        session=session, hardware_uids=hardware_uid,
+        ecosystem_uids=ecosystems_uid, levels=hardware_level,
+        types=hardware_type, models=hardware_model, in_use=in_use)
     return hardware
 
 

--- a/src/ouranos/web_server/routes/gaia/sensor.py
+++ b/src/ouranos/web_server/routes/gaia/sensor.py
@@ -29,7 +29,7 @@ current_data_query = Query(default=False, description="Fetch the current data")
 
 historic_data_query = Query(default=False, description="Fetch logged data")
 
-in_use_query = Query(
+in_config_query = Query(
     default=None, description="Only select sensors that are present (True) "
                               "or have been removed (False) from the current "
                               "gaia ecosystems config")
@@ -61,13 +61,13 @@ async def get_sensors(
         current_data: bool = current_data_query,
         historic_data: bool = historic_data_query,
         time_window: timeWindow = Depends(get_time_window),
-        in_use: bool | None = in_use_query,
+        in_use: bool | None = in_config_query,
         session: AsyncSession = Depends(get_session),
 ):
     sensors = await Sensor.get_multiple(
         session=session, hardware_uids=sensors_uid,
         ecosystem_uids=ecosystems_uid, levels=sensors_level, 
-        models=sensors_model, time_window=time_window, in_use=in_use)
+        models=sensors_model, time_window=time_window, in_config=in_use)
     return [
         await sensor.get_overview(
             session, measures, current_data, historic_data, time_window)

--- a/src/ouranos/web_server/routes/gaia/sensor.py
+++ b/src/ouranos/web_server/routes/gaia/sensor.py
@@ -29,6 +29,11 @@ current_data_query = Query(default=False, description="Fetch the current data")
 
 historic_data_query = Query(default=False, description="Fetch logged data")
 
+in_use_query = Query(
+    default=None, description="Only select sensors that are present (True) "
+                              "or have been removed (False) from the current "
+                              "gaia ecosystems config")
+
 
 async def sensor_or_abort(
         session: AsyncSession,
@@ -56,11 +61,13 @@ async def get_sensors(
         current_data: bool = current_data_query,
         historic_data: bool = historic_data_query,
         time_window: timeWindow = Depends(get_time_window),
+        in_use: bool | None = in_use_query,
         session: AsyncSession = Depends(get_session),
 ):
     sensors = await Sensor.get_multiple(
-        session, sensors_uid, ecosystems_uid, sensors_level, sensors_model,
-        time_window)
+        session=session, hardware_uids=sensors_uid,
+        ecosystem_uids=ecosystems_uid, levels=sensors_level, 
+        models=sensors_model, time_window=time_window, in_use=in_use)
     return [
         await sensor.get_overview(
             session, measures, current_data, historic_data, time_window)


### PR DESCRIPTION
Add a `in_config` column for those models

Remove environmental parameters that are not in Gaia `ecosystems.cfg` anymore from the database