### PR TITLE
Bump to version 0.6.0

### DIFF
--- a/src/ouranos/__init__.py
+++ b/src/ouranos/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.3"
+__version__ = "0.6.0"
 
 from ouranos.core.globals import current_app, db, scheduler
 from ouranos.core.config import app_info, configure_logging, setup_config


### PR DESCRIPTION
* Major changes:

- Implement CRUD to transfer request from web api to Gaia instances.

- Add tests to cover all the events and the routes.

- Remove support of Socket.IO as a communication mean with Gaia.

- Fix issues with dispatcher when the connection is done between Ouranos and a Gaia instance.

- Transfer data coming from Gaia to `Aggregator` to `WebServer` to frontend via Socket.IO.

- Add some API routes to ease data retrieval from frontend.

- Enable the use of `Ouranos` as a `systemd` service.

- Bump `pydantic` to version > 2.0.0 and `sqlalchemy` to version > 2.0.0

- Various fixes and reworks (in authentication-related modules and functionality-related modules)