### PR TITLE
Split `Aggregator`'s dispatcher into two

### DIFF
--- a/src/ouranos/aggregator/decorators.py
+++ b/src/ouranos/aggregator/decorators.py
@@ -35,7 +35,6 @@ def dispatch_to_application(func: Callable):
         func_name: str = func.__name__
         event: str = func_name.lstrip("on_")
         await self.ouranos_dispatcher.emit(
-            event, data=data, namespace="application", ttl=15
-        )
+            event, data=data, namespace="application-internal", ttl=15)
         return await func(self, sid, data, *args)
     return wrapper

--- a/src/ouranos/aggregator/events.py
+++ b/src/ouranos/aggregator/events.py
@@ -199,7 +199,7 @@ class GaiaEvents(BaseEvents):
                 "ecosystem_status",
                 {ecosystem.uid: {"status": ecosystem.status, "connected": False}
                  for ecosystem in engine.ecosystems},
-                namespace="application"
+                namespace="application-internal"
             )
             self.logger.info(f"Engine {engine.uid} disconnected")
 
@@ -322,7 +322,7 @@ class GaiaEvents(BaseEvents):
         await self.ouranos_dispatcher.emit(
             "ecosystem_status",
             data=ecosystems_status,
-            namespace="application"
+            namespace="application-internal"
         )
 
     @registration_required
@@ -499,8 +499,8 @@ class GaiaEvents(BaseEvents):
 
         # Dispatch current data
         await self.ouranos_dispatcher.emit(
-            "current_sensors_data", data=sensors_data, namespace="application",
-            ttl=15)
+            "current_sensors_data", data=sensors_data,
+            namespace="application-internal", ttl=15)
         self.logger.debug(f"Sent `current_sensors_data` to the web API")
         # Log current data in memory DB
         async with db.scoped_session() as session:
@@ -548,7 +548,7 @@ class GaiaEvents(BaseEvents):
         # Dispatch the data that will become historic data
         await self.ouranos_dispatcher.emit(
             "historic_sensors_data_update", data=records_to_log,
-            namespace="application", ttl=15)
+            namespace="application-internal", ttl=15)
         self.logger.debug(
             f"Sent `historic_sensors_data_update` to the web API")
         # Log historic data in db
@@ -736,7 +736,7 @@ class GaiaEvents(BaseEvents):
             except (AttributeError, Exception):
                 engine_sid = None
         await self.emit(
-            "turn_actuator", data=data, namespace="/gaia", room=engine_sid,
+            "turn_actuator", data=data, namespace="gaia", room=engine_sid,
             ttl=30)
 
     async def turn_light(

--- a/src/ouranos/core/database/models/gaia.py
+++ b/src/ouranos/core/database/models/gaia.py
@@ -470,8 +470,7 @@ class Ecosystem(InConfigMixin, GaiaBase):
             "countdown": countdown
         }
         await dispatcher.emit(
-            event="turn_actuator", data=data, namespace="aggregator"
-        )
+            event="turn_actuator", data=data, namespace="aggregator-internal")
 
     async def turn_light(
             self,

--- a/src/ouranos/web_server/events/__init__.py
+++ b/src/ouranos/web_server/events/__init__.py
@@ -52,7 +52,7 @@ class ClientEvents(AsyncNamespace):
             event="turn_light",
             data={"ecosystem": ecosystem_uid, "mode": mode, "countdown": countdown},
             room=ecosystem_sid,
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
 
     # @permission_required(Permission.OPERATE)
@@ -74,7 +74,7 @@ class ClientEvents(AsyncNamespace):
             data={
                 "ecosystem": ecosystem_uid, "management": management, "status": status
             },
-            namespace="aggregator",
+            namespace="aggregator-internal",
             room=ecosystem_sid
         )
 

--- a/src/ouranos/web_server/factory.py
+++ b/src/ouranos/web_server/factory.py
@@ -186,7 +186,7 @@ def create_app(config: dict | None = None) -> FastAPI:
 
     # Configure Socket.IO and load the socketio
     logger.debug("Configuring Socket.IO server")
-    dispatcher = DispatcherFactory.get("application")
+    dispatcher = DispatcherFactory.get("application-internal")
     sio_manager = create_sio_manager()
     sio = AsyncServer(
         async_mode='asgi', cors_allowed_origins=[], client_manager=sio_manager)

--- a/src/ouranos/web_server/routes/gaia/ecosystem.py
+++ b/src/ouranos/web_server/routes/gaia/ecosystem.py
@@ -29,7 +29,7 @@ from ouranos.web_server.validate.response.gaia import (
     EcosystemSensorData, HardwareInfo, SensorSkeletonInfo)
 
 
-dispatcher: AsyncDispatcher = DispatcherFactory.get("application")
+dispatcher: AsyncDispatcher = DispatcherFactory.get("application-internal")
 
 
 router = APIRouter(
@@ -105,7 +105,7 @@ async def create_ecosystem(
                 target="ecosystem",
                 data=ecosystem_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to create the new ecosystem '{ecosystem_dict['name']}' "
@@ -156,7 +156,7 @@ async def update_ecosystem(
                 target="ecosystem",
                 data=ecosystem_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to update the ecosystem '{ecosystem.name}' "
@@ -195,7 +195,7 @@ async def delete_ecosystem(
                 target="ecosystem",
                 data=ecosystem.uid,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to delete the ecosystem '{ecosystem.name}' "
@@ -275,7 +275,7 @@ async def update_management(
                 target="management",
                 data=management_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to update the ecosystem '{ecosystem.name}'\' management "
@@ -378,7 +378,7 @@ async def update_ecosystem_lighting(
                 target="lighting",
                 data=lighting_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to update the ecosystem '{ecosystem.name}'\' lighting "
@@ -436,7 +436,7 @@ async def create_environment_parameters(
                 target="environment_parameter",
                 data=environment_parameter_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to create the environment parameter '{parameter}' "
@@ -494,7 +494,7 @@ async def update_environment_parameters(
                 target="environment_parameter",
                 data=environment_parameter_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to update the environment parameter '{parameter}' "
@@ -535,7 +535,7 @@ async def delete_environment_parameters(
                 target="environment_parameter",
                 data=parameter
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to delete the environment parameter '{parameter}' "
@@ -581,7 +581,7 @@ async def create_ecosystem_hardware(
                 target="hardware",
                 data=hardware_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to create the new hardware '{hardware_dict['name']}' "

--- a/src/ouranos/web_server/routes/gaia/hardware.py
+++ b/src/ouranos/web_server/routes/gaia/hardware.py
@@ -22,7 +22,7 @@ from ouranos.web_server.validate.response.gaia import (
     HardwareInfo, HardwareModelInfo)
 
 
-dispatcher: AsyncDispatcher = DispatcherFactory.get("application")
+dispatcher: AsyncDispatcher = DispatcherFactory.get("application-internal")
 
 
 router = APIRouter(
@@ -107,7 +107,7 @@ async def create_hardware(
                 target="hardware",
                 data=hardware_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to create the new hardware '{hardware_dict['name']}' "
@@ -160,7 +160,7 @@ async def update_hardware(
                 target="hardware",
                 data=hardware_dict,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to update the hardware '{hardware.name}' "
@@ -200,7 +200,7 @@ async def delete_hardware(
                 target="hardware",
                 data=uid,
             ).model_dump(),
-            namespace="aggregator",
+            namespace="aggregator-internal",
         )
         return ResultResponse(
             msg=f"Request to delete the hardware '{hardware.name}' "

--- a/src/ouranos/web_server/system_monitor.py
+++ b/src/ouranos/web_server/system_monitor.py
@@ -33,7 +33,7 @@ else:
 class SystemMonitor:
     def __init__(self):
         self.logger: Logger = getLogger("ouranos.aggregator")
-        self.dispatcher = DispatcherFactory.get("application")
+        self.dispatcher = DispatcherFactory.get("application-internal")
         self._stop_event: Event = Event()
         self._task: Task | None = None
 
@@ -69,10 +69,8 @@ class SystemMonitor:
                 "CPU_temp": get_temp(),
             }
             await self.dispatcher.emit(
-                "current_server_data",
-                data={**data, "start_time": START_TIME},
-                namespace="application",
-            )
+                "current_server_data", data={**data, "start_time": START_TIME},
+                namespace="application-internal")
             async with db.scoped_session() as session:
                 await SystemDbCache.insert_data(session, data)
             if logging_period and datetime.now().minute % logging_period == 0:

--- a/tests/aggregator/test_events.py
+++ b/tests/aggregator/test_events.py
@@ -68,7 +68,7 @@ async def test_on_disconnect(
     emitted = mock_dispatcher.emit_store[0]
     assert emitted["event"] == "ecosystem_status"
     assert emitted["data"] == {}
-    assert emitted["namespace"] == "application"
+    assert emitted["namespace"] == "application-internal"
 
 
 @pytest.mark.asyncio
@@ -128,7 +128,7 @@ async def test_on_base_info(
     assert emitted["data"] == [
         {"status": g_data.base_info["status"], 'uid': g_data.base_info["uid"]}
     ]
-    assert emitted["namespace"] == "application"
+    assert emitted["namespace"] == "application-internal"
 
     async with naive_db.scoped_session() as session:
         ecosystem = await Ecosystem.get(session, ecosystem_id=g_data.ecosystem_uid)
@@ -236,7 +236,7 @@ async def test_on_sensors_data(
         'timestamp': g_data.sensors_data["timestamp"],
         'value': g_data.sensor_record.value
     }]
-    assert emitted["namespace"] == "application"
+    assert emitted["namespace"] == "application-internal"
 
     async with ecosystem_aware_db.scoped_session() as session:
         sensor_data = (await SensorDbCache.get_recent(session))[0]


### PR DESCRIPTION
- Use the base one for communication with gaia and an "aggregator-internal" for communication with other internal processes, such as the "application" dispatcher (renamed "application-internal")