### PR TITLE
Drop support of Python 3.9 and 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "An app to manage Gaia instances"
 authors = [
     {name = "Valentin Ambroise", email = "valentin.ambroise@outlook.com"}
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 readme = "README.md"
 license = {file = "LICENSE"}
 dynamic = ["version"]


### PR DESCRIPTION
- Ouranos relies on typing spec that appeared in Python 3.11